### PR TITLE
Add micro:bit LED matrix and resource usage APIs

### DIFF
--- a/pxt_modules/base/gc.cpp
+++ b/pxt_modules/base/gc.cpp
@@ -92,6 +92,21 @@ Buffer getGCStats() {
 }
 
 //%
+uint32_t heapUsed() {
+    return gcStats.totalBytes - gcStats.lastFreeBytes;
+}
+
+//%
+uint32_t heapTotal() {
+    return gcStats.totalBytes;
+}
+
+//%
+uint32_t heapFree() {
+    return gcStats.lastFreeBytes;
+}
+
+//%
 void popThreadContext(ThreadContext *ctx);
 //%
 ThreadContext *pushThreadContext(void *sp, void *endSP);

--- a/pxt_modules/base/gcstats.ts
+++ b/pxt_modules/base/gcstats.ts
@@ -13,6 +13,15 @@ namespace control {
         minFreeBytes: number;
     }
 
+    //% shim=pxt::heapUsed
+    export function heapUsed(): number;
+
+    //% shim=pxt::heapTotal
+    export function heapTotal(): number;
+
+    //% shim=pxt::heapFree
+    export function heapFree(): number;
+
     /**
      * Get various statistics about the garbage collector (GC)
      */

--- a/pxt_modules/core/ledmatrix.cpp
+++ b/pxt_modules/core/ledmatrix.cpp
@@ -1,0 +1,22 @@
+#include "pxt.h"
+
+#ifdef MICROBIT_CODAL
+#include "MicroBit.h"
+using namespace codal;
+extern MicroBit uBit;
+
+namespace ledmatrix {
+
+//%
+void plot(int x, int y) {
+    if (0 <= x && x < 5 && 0 <= y && y < 5)
+        uBit.display.image.setPixelValue(x, y, 255);
+}
+
+//%
+void clear() {
+    uBit.display.clear();
+}
+
+} // namespace ledmatrix
+#endif

--- a/pxt_modules/core/ledmatrix.ts
+++ b/pxt_modules/core/ledmatrix.ts
@@ -1,0 +1,10 @@
+/**
+ * Control the 5x5 LED matrix.
+ */
+//% color="#ff0000" weight=85 icon="\uf005"
+namespace ledmatrix {
+    //% shim=ledmatrix::plot
+    export function plot(x: number, y: number): void;
+    //% shim=ledmatrix::clear
+    export function clear(): void;
+}

--- a/pxt_modules/core/pxt.json
+++ b/pxt_modules/core/pxt.json
@@ -41,6 +41,8 @@
         "keyvaluestorage.cpp",
         "keyvaluestorage.ts",
         "leveldetector.ts",
+        "ledmatrix.cpp",
+        "ledmatrix.ts",
         "pxtparts.json"
     ],
     "testFiles": [

--- a/pxt_modules/settings/settings.cpp
+++ b/pxt_modules/settings/settings.cpp
@@ -164,4 +164,16 @@ RefCollection *_list(String prefix) {
     return res;
 }
 
+//%
+int storageSize() {
+    auto s = mountedStorage();
+    return s->fs.totalSize();
+}
+
+//%
+int storageFree() {
+    auto s = mountedStorage();
+    return s->fs.freeSize();
+}
+
 } // namespace settings

--- a/pxt_modules/settings/settings.ts
+++ b/pxt_modules/settings/settings.ts
@@ -25,6 +25,12 @@ namespace settings {
     //% shim=settings::_list
     declare function _list(prefix: string): string[];
 
+    //% shim=settings::storageSize
+    export function storageSize(): int32;
+
+    //% shim=settings::storageFree
+    export function storageFree(): int32;
+
     export function runNumber() {
         return readNumber(RUN_KEY) || 0
     }


### PR DESCRIPTION
## Summary
- expose LED matrix controls for micro:bit
- add heap usage helpers
- report total and free persistent storage

## Testing
- `npx pxt test` *(fails: Could not find PXT; maybe try 'pxt target microbit')*

------
https://chatgpt.com/codex/tasks/task_b_68b73fe83fc48332916b397fab70cab4